### PR TITLE
Bump process version

### DIFF
--- a/abcnotation.cabal
+++ b/abcnotation.cabal
@@ -31,6 +31,6 @@ library
                         prettify,
                         parsec,
                         -- debug
-                        process             >= 1.2 && < 1.3
+                        process             >= 1.6 && < 2
     hs-source-dirs:     src
     default-language:   Haskell2010


### PR DESCRIPTION
`abcnotation` is now marked broken in nixpkgs, which is at least one of the reasons why `music-suite` won't build. Maybe this will help? The package builds with this change.